### PR TITLE
[FIX] Darwin temporary password file access

### DIFF
--- a/shell_scripts/lukso
+++ b/shell_scripts/lukso
@@ -5,6 +5,7 @@ COMMAND=$1
 COMMAND_ARG=$2
 USE_CONFIG_FILE=false
 FORCE=false
+VALIDATOR_LOOPS=5
 #####
 
 ##### network info
@@ -621,7 +622,7 @@ start_validator() {
   if [[ -n $TEMPPASSFILE ]]; then
     # Wait until validator starts
     TRIES=0
-    while [[ $TRIES -lt 5 ]]; do
+    while [[ $TRIES -lt VALIDATOR_LOOPS ]]; do
       sleep 1
       echo -n " . "
       TRIES=$((TRIES+1))
@@ -629,11 +630,11 @@ start_validator() {
 
     if [[ ! $(pgrep -x "lukso-validator") ]]; then
       echo "ERROR: Cannot start validator"
-      break;
-    else
-      echo -n "OK "
-      echo
+      exit
     fi
+
+    echo -n "OK "
+    echo
 
     rm $TEMPPASSFILE
   fi

--- a/shell_scripts/lukso
+++ b/shell_scripts/lukso
@@ -621,14 +621,20 @@ start_validator() {
   if [[ -n $TEMPPASSFILE ]]; then
     # Wait until validator starts
     TRIES=0
-    while [[ ! $(lsof -t -i:7000) ]]; do
+    while [[ $TRIES -lt 5 ]]; do
       sleep 1
-      if [[ $TRIES -ge 10 ]]; then
-        echo "ERROR: Cannot start validator"
-        break;
-      fi
+      echo -n " . "
       TRIES=$((TRIES+1))
     done
+
+    if [[ ! $(pgrep -x "lukso-validator") ]]; then
+      echo "ERROR: Cannot start validator"
+      break;
+    else
+      echo -n "OK "
+      echo
+    fi
+
     rm $TEMPPASSFILE
   fi
 }


### PR DESCRIPTION
This PR changes method of "waiting" until validator starts so the temporary password could be loaded and deleted.